### PR TITLE
Use context.ready event

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,55 +3,55 @@
 
 module.exports = {
     /**
-     * Should the process continue to run as long as the files 
-     * are being watched? If `false` when using `fsevents` no 
-     * more events will be emitted after `ready` even if the 
+     * Should the process continue to run as long as the files
+     * are being watched? If `false` when using `fsevents` no
+     * more events will be emitted after `ready` even if the
      * process continues to run.
      */
     persistence: true,
     /**
-     * Defines files/paths to be ignored. The whole relative 
-     * or absolute path is tested, not just filename. 
-     * If a function with two arguments is provided, it gets 
-     * called twice per path - once with a single argument 
-     * (the path), second time with two arguments (the path 
+     * Defines files/paths to be ignored. The whole relative
+     * or absolute path is tested, not just filename.
+     * If a function with two arguments is provided, it gets
+     * called twice per path - once with a single argument
+     * (the path), second time with two arguments (the path
      * and the fs.Stats object of that path).
-     * 
+     *
      * @see https://github.com/micromatch/anymatch
      */
     ignored: undefined,
     /**
-     * If set to `false` then `add`/`addDir` events are 
-     * also emitted for matching paths while instantiating 
-     * the watching as chokidar discovers these file paths 
+     * If set to `false` then `add`/`addDir` events are
+     * also emitted for matching paths while instantiating
+     * the watching as chokidar discovers these file paths
      * (before the `ready` event).
      */
     ignoreInitial: false,
     /**
-     * When false, only the symlinks themselves will be 
-     * watched for changes instead of following the link 
-     * references and bubbling events through the link's 
+     * When false, only the symlinks themselves will be
+     * watched for changes instead of following the link
+     * references and bubbling events through the link's
      * path.
      */
     followSymlinks: true,
     /**
-     * The base directory from which watch paths are to be 
-     * derived. Paths emitted with events will be relative 
+     * The base directory from which watch paths are to be
+     * derived. Paths emitted with events will be relative
      * to this.
      */
     cwd: undefined,
     /**
-     *  If set to true then the strings passed to 
-     * .watch() and .add() are treated as literal path 
+     *  If set to true then the strings passed to
+     * .watch() and .add() are treated as literal path
      * names, even if they look like globs.
      */
     disableGlobbing: false,
     /**
-     * If set, limits how many levels of subdirectories 
+     * If set, limits how many levels of subdirectories
      * will be traversed. Defaults to `undefined`.
      * We set it to 1 so we can get commands grouped by
      * one level of folders.
      */
-    depth: 1,
+    depth: 5,
     awaitForFinish: true
 };

--- a/lib/init.js
+++ b/lib/init.js
@@ -2,13 +2,14 @@
 const extend = require('gextend');
 const defaults = require('./defaults');
 const makeCommandReloader = require('./command-reloader');
+
 /**
  * Hot Command Reloading
- * 
- * This module enables us to modify commands locally 
+ *
+ * This module enables us to modify commands locally
  * during development and will reload the command in
  * memory so that it is executed with the latest code.
- * 
+ *
  * @param {Application} context Application core context
  * @param {Object} config Configuration object
  * @param {String} config.moduleid Set by core.io
@@ -18,11 +19,16 @@ module.exports = function(context, config) {
     const logger = context.getLogger(config.moduleid);
 
     if (context.environment !== 'development') {
-        logger.info('Skip initalizing Hot Command Reload module...');
+        logger.info('Skip initializing Hot Command Reload module...');
         return {};
     }
 
-    context.once('modules.resolved', _ => {
+    const requireUncached = function $requireUncached(mdl) {
+        delete require.cache[require.resolve(mdl)];
+        return require(mdl);
+    };
+
+    context.once('context.ready', _ => {
 
         logger.info('Initialize command module reloader!');
 
@@ -34,12 +40,12 @@ module.exports = function(context, config) {
             logger.info('Command updated: %s', filepath);
             context.reloadCommand(filepath, requireUncached(filepath));
         });
-
-        function requireUncached(mdl) {
-            delete require.cache[require.resolve(mdl)];
-            return require(mdl);
-        }
     });
+
+    /**
+     * Expose requireUncached function.
+     */
+    context.provide('requireUncached', requireUncached);
 
     return {};
 };

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
   "homepage": "https://github.com/goliatone/core.io-command-reloader#readme",
   "devDependencies": {
     "bogota": "^2.0.4",
-    "nyc": "^10.3.2",
-    "proxyquire": "^1.7.11",
-    "sinon": "^7.3.2",
+    "nyc": "^15.1.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^13.0.1",
     "tap-spec": "^5.0.0",
-    "tape": "^4.11.0",
+    "tape": "^5.5.2",
     "tape-catch": "^1.0.6",
     "watch": "^1.0.2"
   },
   "dependencies": {
-    "chokidar": "^3.4.3",
+    "chokidar": "^3.5.3",
     "gextend": "^0.8.0"
   }
 }


### PR DESCRIPTION
This PR fixes an issue in which `modules.resolved` would not resolve in the desired order. We use `context.ready` as this ensures all modules are loaded and dependencies solved.

Updated the max depth for nested folders to 5.